### PR TITLE
set-output: Replace set-ouput usage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Get the tag
         id: get_tag
-        run: echo ::set-output name=TAG::${GITHUB_REF/refs\/tags\//}
+        run: echo TAG=${GITHUB_REF/refs\/tags\//} >> $GITHUB_OUTPUT
 
       - name: Tag & push image
         run: |

--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ func run() error {
 		return fmt.Errorf("failed to render template: %v", err)
 	}
 
-	fmt.Printf("::set-output name=result::%s", escape(output))
+	os.Setenv("GITHUB_OUTPUT", fmt.Sprintf("result=%s", escape(output)))
 
 	if len(c.ResultPath) != 0 {
 		err := ioutil.WriteFile(c.ResultPath, []byte(output), 0644)

--- a/main.go
+++ b/main.go
@@ -56,7 +56,11 @@ func run() error {
 		return fmt.Errorf("failed to render template: %v", err)
 	}
 
-	os.Setenv("GITHUB_OUTPUT", fmt.Sprintln(os.Getenv("GITHUB_OUTPUT"))+fmt.Sprintf("result=%s", escape(output)))
+	if os.Getenv("GITHUB_OUTPUT") != "" {
+		os.Setenv("GITHUB_OUTPUT", fmt.Sprintln(os.Getenv("GITHUB_OUTPUT"))+fmt.Sprintf("result=%s", escape(output)))
+	} else {
+		os.Setenv("GITHUB_OUTPUT", fmt.Sprintf("result=%s", escape(output)))
+	}
 
 	if len(c.ResultPath) != 0 {
 		err := ioutil.WriteFile(c.ResultPath, []byte(output), 0644)

--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ func run() error {
 		return fmt.Errorf("failed to render template: %v", err)
 	}
 
-	os.Setenv("GITHUB_OUTPUT", fmt.Sprintf("result=%s", escape(output)))
+	os.Setenv("GITHUB_OUTPUT", fmt.Sprintln(os.Getenv("GITHUB_OUTPUT"))+fmt.Sprintf("result=%s", escape(output)))
 
 	if len(c.ResultPath) != 0 {
 		err := ioutil.WriteFile(c.ResultPath, []byte(output), 0644)


### PR DESCRIPTION
## Summary
Since this is the only use set-output used in this action, we can directly set `$GITHUB_OUTPUT` to the result.

## QA 
Make sure the render-template action still works properly.
Might be easier to test this after merging this pull. 
  - We can update the sha in the workflow and create a test pull request. https://github.com/iFixit/ifixit/blob/37a8c72dcd83daa3ca6748667488d654002a95f2/.github/workflows/E2E.yml#L106 
  - Then check the webpack comment. 


Connects: https://github.com/iFixit/ifixit/issues/45080